### PR TITLE
Take advantage of more CoffeeScript syntax sugar

### DIFF
--- a/src/jsonp.coffee
+++ b/src/jsonp.coffee
@@ -38,7 +38,7 @@ JSONP = (options = {}) ->
             params.complete { url: script.src, event: evt }, params
 
         script.onload = script.onreadystatechange = ->
-            return if done or !@readyState or @readyState in ['loaded', 'complete']
+            return if done or @readyState not in ['loaded', 'complete']
             done = true
             if script
                 script.onload = script.onreadystatechange = null

--- a/src/jsonp.coffee
+++ b/src/jsonp.coffee
@@ -44,7 +44,7 @@ JSONP = (options = {}) ->
                 script.onload = script.onreadystatechange = null
                 script.parentNode?.removeChild script
                 script = null
-        head or= window.document.getElementsByTagName('head')[0] or window.document.documentElement
+        head = window.document.getElementsByTagName('head')[0] or window.document.documentElement
         # (see jQuery bugs #2709 and #4378)
         head.insertBefore script, head.firstChild
 

--- a/src/jsonp.coffee
+++ b/src/jsonp.coffee
@@ -70,7 +70,7 @@ randomString = (length) ->
     return str
 
 objectToURI = (obj) ->
-    data = [encode(key) + '=' + encode value for key, value of obj]
+    data = (encode(key) + '=' + encode value for key, value of obj)
     return data.join '&'
 
 if define?.amd then define -> JSONP


### PR DESCRIPTION
This is a _very_ minor change to use some more of the syntax sugar available in CoffeeScript. For example: default parameter-values, `or=`, the null-safe navigation operator `?.`, and various other shorthand syntax.

There is one logic change, between lines 41 and 47. A conditional block was changed to an early return, to move more code to the left.